### PR TITLE
update release procedure

### DIFF
--- a/.github/workflows/pythonrelease.yml
+++ b/.github/workflows/pythonrelease.yml
@@ -16,11 +16,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade --force-reinstall twine pep517
+        python -m pip install --upgrade --force-reinstall pep517
     - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python -m pep517.build --binary --source --out-dir w .
-        twine upload w/*
+        python -m pep517.build --binary --source --out-dir dist .
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pythonrelease.yml
+++ b/.github/workflows/pythonrelease.yml
@@ -16,10 +16,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade --force-reinstall pep517
+        python -m pip install --upgrade --force-reinstall build
     - name: Build and publish
       run: |
-        python -m pep517.build --binary --source --out-dir dist .
+        python -m build .
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
use pypi token instead of username/password auth and pypi's release github action to publish package